### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "categories": [
     "Linters",
+    "Formatters",
     "Other"
   ],
   "activationEvents": [


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.
