### PR TITLE
Changed arguments default

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,7 @@
         },
         "phpformatter.arguments": {
           "type": "array",
-          "default": [
-            "--level=psr2"
-          ],
+          "default": [],
           "description": "Add arguments to the executed fix command, like so: ['--level=psr2', '--fixers=linefeed,short_tag,indentation']."
         },
         "phpformatter.additionalExtensions": {


### PR DESCRIPTION
I've changed phpformatter.arguments to empty string default because it doesn't work with v2 PHP cs fixer